### PR TITLE
Add a new class to deal with non-transferring pressable buttons

### DIFF
--- a/src/main/java/net/oijon/susquehanna/gui/components/PhonemeButton.java
+++ b/src/main/java/net/oijon/susquehanna/gui/components/PhonemeButton.java
@@ -17,9 +17,9 @@ import net.oijon.susquehanna.App;
 public class PhonemeButton extends Parent {
 
 	private Button phonemeButton;
-	private ToolButton add;
-	private ToolButton edit;
-	private ToolButton trash;
+	private PressableButton add;
+	private PressableButton edit;
+	private PressableButton trash;
 	private String phoneme = "";
 	private boolean isEditable = false;
 	private boolean inPhono = false;
@@ -231,7 +231,7 @@ public class PhonemeButton extends Parent {
 	 * Builds the add button that appears when a PhonemeButton is not in a Phonology
 	 */
 	private void buildAdd() {
-		add = new ToolButton("add");		
+		add = new PressableButton("add");		
 		add.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
 		PhonemeButton me = this;
 		add.setOnAction(new EventHandler<ActionEvent>() {
@@ -267,7 +267,7 @@ public class PhonemeButton extends Parent {
 	 * Builds the edit button that appears when a PhonemeButton is in a Phonology
 	 */
 	private void buildEdit() {
-		edit = new ToolButton("edit");
+		edit = new PressableButton("edit");
 		edit.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
 		edit.setOnAction(new EventHandler<ActionEvent>() {
 			@Override
@@ -285,7 +285,7 @@ public class PhonemeButton extends Parent {
 	 * Builds the trash button that appears when a PhonemeButton is in a Phonology
 	 */
 	private void buildTrash() {
-		trash = new ToolButton("trash");
+		trash = new PressableButton("trash");
 		trash.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
 		PhonemeButton me = this;
 		trash.setOnAction(new EventHandler<ActionEvent>() {

--- a/src/main/java/net/oijon/susquehanna/gui/components/PressableButton.java
+++ b/src/main/java/net/oijon/susquehanna/gui/components/PressableButton.java
@@ -1,0 +1,72 @@
+package net.oijon.susquehanna.gui.components;
+
+import javafx.event.EventHandler;
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.paint.Color;
+import javafx.scene.text.TextAlignment;
+import net.oijon.olog.Log;
+import net.oijon.susquehanna.App;
+
+public class PressableButton extends Button {
+	
+	protected Log log = App.getLog();
+	public String id;
+
+	/**
+	 * Constructs a button.
+	 * @param id The (non-unique) ID of the button. Used for textures.
+	 */
+	public PressableButton(String id) {
+		this.id = id;
+		String fileName = "/img/";
+		fileName += id;
+		fileName += ".png";
+		try {
+			Image img = new Image(PressableButton.class.getResourceAsStream(fileName));
+			ImageView imgV = new ImageView(img);
+			this.setGraphic(imgV);
+			this.setPadding(Insets.EMPTY);
+	        this.setContentDisplay(ContentDisplay.TOP);
+	        this.setBackground(null);
+	        this.setTextAlignment(TextAlignment.CENTER);
+	        this.setTextFill(Color.WHITE);
+	        createActions();
+		} catch (NullPointerException e) {
+			log.err("Unable to load button image for " + id
+					+ " at " + fileName + "! Defaulting to text-only button...");
+			this.setText(id);
+		}
+	}
+	
+	/**
+	 * Creates the button images for when pressed
+	 */
+	private void createActions() {
+		// only works because of pass-by-reference
+		// have to do this because otherwise the eventhandlers go
+		//
+		//  🥺  is for me?
+		// 👉👈
+		Button button = this;
+		final String fileName = "/img/" + id;
+		
+		button.setOnMousePressed(new EventHandler<MouseEvent>() {
+	       	@Override
+	       	public void handle(MouseEvent event) {
+	       		button.setGraphic(new ImageView(new Image(PressableButton.class.getResourceAsStream(fileName + "-pressed.png"))));
+	       	}
+	       });
+		button.setOnMouseReleased(new EventHandler<MouseEvent>() {
+	       	@Override
+	       	public void handle(MouseEvent event) {
+	       		button.setGraphic(new ImageView(new Image(PressableButton.class.getResourceAsStream(fileName + ".png"))));
+	     	}
+	    });
+	}
+	
+}

--- a/src/main/java/net/oijon/susquehanna/gui/components/ToolButton.java
+++ b/src/main/java/net/oijon/susquehanna/gui/components/ToolButton.java
@@ -4,15 +4,6 @@ import java.util.List;
 
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
-import javafx.geometry.Insets;
-import javafx.scene.control.Button;
-import javafx.scene.control.ContentDisplay;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.scene.input.MouseEvent;
-import javafx.scene.paint.Color;
-import javafx.scene.text.TextAlignment;
-import net.oijon.olog.Log;
 import net.oijon.susquehanna.App;
 import net.oijon.susquehanna.LocaleBundle;
 import net.oijon.susquehanna.gui.scenes.Book;
@@ -22,37 +13,18 @@ import net.oijon.susquehanna.gui.scenes.Book;
  * @author alex
  *
  */
-public class ToolButton extends Button {
+public class ToolButton extends PressableButton {
 	
-	LocaleBundle lb = App.lb;
-	Log log = App.getLog();
-	private String id;
+	protected LocaleBundle lb = App.lb;
 
 	/**
 	 * Constructs a button. 
 	 * Before ToolButton.createActions(new ToolButton()) instead!
 	 * @param name The text under the button
 	 */
-	public ToolButton(String name) {
-		id = name;
-		String fileName = "/img/";
-		fileName += name;
-		fileName += ".png";
-		this.setText(lb.get("tool." + name));
-		try {
-			Image img = new Image(ToolButton.class.getResourceAsStream(fileName));
-			ImageView imgV = new ImageView(img);
-			this.setGraphic(imgV);
-			this.setPadding(Insets.EMPTY);
-	        this.setContentDisplay(ContentDisplay.TOP);
-	        this.setBackground(null);
-	        this.setTextAlignment(TextAlignment.CENTER);
-	        this.setTextFill(Color.WHITE);
-	        createActions();
-		} catch (NullPointerException e) {
-			log.err("Unable to load button image for " + name
-					+ " at " + fileName + "! Defaulting to text-only button...");
-		}
+	public ToolButton(String id) {
+		super(id);
+		this.setText(lb.get("tool." + id));
 		createTransferAction();
 	}
 	/**
@@ -81,32 +53,6 @@ public class ToolButton extends Button {
 	 */
 	private void createTransferAction() {
 		createTransferAction(id);
-	}
-	
-	/**
-	 * Creates the button images for when pressed
-	 */
-	private void createActions() {
-		// only works because of pass-by-reference
-		// have to do this because otherwise the eventhandlers go
-		//
-		//  🥺  is for me?
-		// 👉👈
-		Button button = this;
-		final String fileName = "/img/" + id;
-		
-		button.setOnMousePressed(new EventHandler<MouseEvent>() {
-	       	@Override
-	       	public void handle(MouseEvent event) {
-	       		button.setGraphic(new ImageView(new Image(ToolButton.class.getResourceAsStream(fileName + "-pressed.png"))));
-	       	}
-	       });
-		button.setOnMouseReleased(new EventHandler<MouseEvent>() {
-	       	@Override
-	       	public void handle(MouseEvent event) {
-	       		button.setGraphic(new ImageView(new Image(ToolButton.class.getResourceAsStream(fileName + ".png"))));
-	     	}
-	    });
 	}
 	
 }


### PR DESCRIPTION
Fixes #46. There is now a new class to deal with non-transferring pressable buttons, such as those found in the phonology edit area.