### PR TITLE
javadocs now compile

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.oijon</groupId>
   <artifactId>Susquehanna</artifactId>
-  <version>0.1.2</version>
+  <version>0.2.0</version>
   <build>
     <plugins>
       <plugin>

--- a/src/main/java/net/oijon/susquehanna/gui/components/ToolButton.java
+++ b/src/main/java/net/oijon/susquehanna/gui/components/ToolButton.java
@@ -18,9 +18,8 @@ public class ToolButton extends PressableButton {
 	protected LocaleBundle lb = App.lb;
 
 	/**
-	 * Constructs a button. 
-	 * Before ToolButton.createActions(new ToolButton()) instead!
-	 * @param name The text under the button
+	 * Constructs a button.
+	 * @param id The ID of the book this button should transfer to
 	 */
 	public ToolButton(String id) {
 		super(id);
@@ -29,7 +28,7 @@ public class ToolButton extends PressableButton {
 	}
 	/**
 	 * Sets the book that this button should transfer the main stage to
-	 * @param book The book to be changed to when this button is pressed
+	 * @param id The book to be changed to when this button is pressed
 	 * @deprecated as of 0.2.0, as the id should now be the name.
 	 */
 	public void createTransferAction(String id) {

--- a/src/main/java/net/oijon/susquehanna/gui/scenes/Book.java
+++ b/src/main/java/net/oijon/susquehanna/gui/scenes/Book.java
@@ -90,7 +90,7 @@ public abstract class Book extends Scene {
 	
 	/**
 	 * Adds any amount of JavaFX nodes to the left page
-	 * @param nodes The JavaFX node to be added to the page
+	 * @param node The JavaFX node to be added to the page
 	 */
 	public void addToLeft(Node node) {
 		leftPage.getChildren().add(node);
@@ -99,7 +99,7 @@ public abstract class Book extends Scene {
 	
 	/**
 	 * Adds any amount of JavaFX nodes to the right page
-	 * @param nodes The JavaFX node to be added to the page
+	 * @param node The JavaFX node to be added to the page
 	 */
 	public void addToRight(Node node) {
 		rightPage.getChildren().add(node);


### PR DESCRIPTION
Fixes #57. This makes javadocs compile correctly. Perhaps next version it'd be a good idea to go through everything and make sure there's a javadoc entry.